### PR TITLE
Applying patch from vantron:

### DIFF
--- a/sound/soc/codecs/mt6357.c
+++ b/sound/soc/codecs/mt6357.c
@@ -3787,8 +3787,10 @@ static void Speaker_Amp_Change(bool enable)
 		/* disable Pull-down HPL/R to AVSS28_AUD */
 		if (mIsNeedPullDown)
 			hp_pull_down(false);
+
+	}
 #if 0
-	} else {
+	else {
 		pr_debug("%s(), enable %d\n", __func__, enable);
 		/* LOL mux to open */
 		Ana_Set_Reg(AUDDEC_ANA_CON4, 0x0000, 0x3 << 2);


### PR DESCRIPTION
From w.feng@vantrontech.com.cn:
If turn on speaker DAC when system boot up and do NOT turn off DAC of PMIC, it can fix the louder issue. You can turn off DAC when system suspend, please check attached patch file for details.