### PR TITLE
Applied Andrew at MTK patch about LVDS driver

### DIFF
--- a/drivers/gpu/drm/mediatek/mtk_dpi.c
+++ b/drivers/gpu/drm/mediatek/mtk_dpi.c
@@ -654,8 +654,8 @@ static void mtk_dpi_encoder_disable(struct drm_encoder *encoder)
 	struct mtk_dpi *dpi = mtk_dpi_from_encoder(encoder);
 
 	if (dpi->panel) {
-		drm_panel_unprepare(dpi->panel);
 		drm_panel_disable(dpi->panel);
+		drm_panel_unprepare(dpi->panel);
 	}
 
 	mtk_dpi_power_off(dpi);
@@ -667,6 +667,10 @@ static void mtk_dpi_encoder_enable(struct drm_encoder *encoder)
 
 	mtk_dpi_power_on(dpi);
 	mtk_dpi_set_display_mode(dpi, &dpi->mode);
+
+	if (dpi->panel) {
+		drm_panel_enable(dpi->panel);
+	}
 }
 
 static int mtk_dpi_atomic_check(struct drm_encoder *encoder,
@@ -710,10 +714,9 @@ static void mtk_dpi_config(struct mtk_ddp_comp *comp, unsigned int w,
 {
 	struct mtk_dpi *dpi = container_of(comp, struct mtk_dpi, ddp_comp);
 
-	if(dpi->panel) {
+	if(dpi->panel)
 		drm_panel_prepare(dpi->panel);
-		drm_panel_enable(dpi->panel);
-	}
+
 }
 
 static void mtk_dpi_start(struct mtk_ddp_comp *comp)

--- a/drivers/gpu/drm/mediatek/mtk_drm_crtc.c
+++ b/drivers/gpu/drm/mediatek/mtk_drm_crtc.c
@@ -284,12 +284,12 @@ static int mtk_crtc_ddp_hw_init(struct mtk_drm_crtc *mtk_crtc)
 		if (prev == DDP_COMPONENT_OVL0)
 			mtk_ddp_comp_bgclr_in_on(comp);
 
-		mtk_ddp_comp_config(comp, width, height, vrefresh, bpc);
-		mtk_ddp_comp_start(comp);
-
 		if (curr == DDP_COMPONENT_LVDS)
 			mtk_ddp_lvds_sys_cfg_lvds(mtk_crtc->config_regs,
 					     mtk_crtc->mmsys_reg_data);
+
+		mtk_ddp_comp_config(comp, width, height, vrefresh, bpc);
+		mtk_ddp_comp_start(comp);
 	}
 
 	/* Initially configure all planes */

--- a/drivers/gpu/drm/mediatek/mtk_lvds.c
+++ b/drivers/gpu/drm/mediatek/mtk_lvds.c
@@ -62,6 +62,7 @@
 #define RG_VPLL_LVDS_TTL_EN			BIT(7)
 #define RG_VPLL_TXDIV5_EN			BIT(11)
 #define RG_VPLL_SDM_PWR_ON			BIT(13)
+#define RG_VPLL_SDM_ISO_EN			BIT(14)
 
 struct mtk_lvds {
 	struct mtk_ddp_comp ddp_comp;
@@ -110,17 +111,28 @@ static void mtk_lvds_config(struct mtk_ddp_comp *comp, unsigned int w,
 	lvds_update_bits(lvds->regs_ana, MIPI_LVDS_ANA10,
 			 RG_LVDSTX_LDO1LPF_EN, RG_LVDSTX_LDO1LPF_EN);
 
-	lvds_update_bits(lvds->regs_ana, MIPI_LVDS_ANA14,
-			 RG_VPLL_PREDIV_MASK | RG_VPLL_EN |
-			 RG_VPLL_RESERVE,
-			 RG_VPLL_PREDIV | RG_VPLL_EN | RG_VPLL_RESERVE);
+	writel(RG_VPLL_SDM_ISO_EN | RG_VPLL_SDM_PWR_ON | RG_VPLL_TXDIV5_EN |
+	       RG_VPLL_LVDS_TTL_EN | RG_VPLL_LVDS_DPIX_DIV2 |
+	       RG_VPLL_LVDS_EN | RG_VPLL_TXDIV1,
+	       lvds->regs_ana + MIPI_LVDS_ANA1C);
 
-	writel(RG_VPLL_SDM_PCW, lvds->regs_ana + MIPI_LVDS_ANA18);
+	udelay(20);
 
 	writel(RG_VPLL_SDM_PWR_ON | RG_VPLL_TXDIV5_EN |
 	       RG_VPLL_LVDS_TTL_EN | RG_VPLL_LVDS_DPIX_DIV2 |
 	       RG_VPLL_LVDS_EN | RG_VPLL_TXDIV1,
 	       lvds->regs_ana + MIPI_LVDS_ANA1C);
+
+	udelay(20);
+
+	writel(RG_VPLL_SDM_PCW, lvds->regs_ana + MIPI_LVDS_ANA18);
+
+	udelay(20);
+
+	lvds_update_bits(lvds->regs_ana, MIPI_LVDS_ANA14,
+			 RG_VPLL_PREDIV_MASK | RG_VPLL_EN |
+			 RG_VPLL_RESERVE,
+			 RG_VPLL_PREDIV | RG_VPLL_EN | RG_VPLL_RESERVE);
 }
 
 static void mtk_lvds_start(struct mtk_ddp_comp *comp)

--- a/drivers/gpu/drm/panel/panel-avd-tt70ws-cn-102-a.c
+++ b/drivers/gpu/drm/panel/panel-avd-tt70ws-cn-102-a.c
@@ -126,12 +126,6 @@ static int lvds_panel_enable(struct drm_panel *panel)
 		return 0;
 
 	mdelay(20);
-
-	gpiod_set_value(lvds->lcd_rst_gpio, 1);
-	mdelay(20);
-	gpiod_set_value(lvds->lcd_rst_gpio, 0);
-	mdelay(50);
-
 	gpiod_set_value(lvds->lcd_rst_gpio, 1);
 	mdelay(10);
 	gpiod_set_value(lvds->lcd_stb_gpio, 1);


### PR DESCRIPTION
Due to some issues like disordered and dual display after bootup, MTK released some patches that modified LVDS initialization sequence.
[display.patch](https://github.com/geappliances/android.appliance-linux/files/11099557/display.patch)
