### PR TITLE
arch: arm64: dts: add labels to mt8365 cooling maps

### DIFF
--- a/arch/arm64/boot/dts/mediatek/mt8365.dtsi
+++ b/arch/arm64/boot/dts/mediatek/mt8365.dtsi
@@ -247,7 +247,7 @@
 			};
 
 			cooling-maps {
-				map0 {
+				map0: map0 {
 					trip = <&threshold>;
 					cooling-device =
 						<&cpu0
@@ -264,7 +264,7 @@
 						 THERMAL_NO_LIMIT>;
 					contribution = <100>;
 				};
-				map1 {
+				map1: map1 {
 					trip = <&target>;
 					cooling-device =
 						<&cpu0

--- a/drivers/thermal/cpu_cooling.c
+++ b/drivers/thermal/cpu_cooling.c
@@ -332,7 +332,7 @@ static int cpufreq_set_cur_state(struct thermal_cooling_device *cdev,
 
 	ret = freq_qos_update_request(&cpufreq_cdev->qos_req,
 			cpufreq_cdev->freq_table[state].frequency);
-	if (ret > 0)
+	if (ret >= 0)
 		cpufreq_cdev->cpufreq_state = state;
 
 	return ret;


### PR DESCRIPTION
From BL:
Add labels to the mt8365 cooling maps so that board specific devicetrees might be able to reference them.
 
 [WORKAROUND] thermal: ensure cooling device has correct state

From BL:
The initial curent state of a cooling device is always zero. It will
only be initialized when thermal governor starts to act. If it happens
that the actual current state of the device is also the one targeted by
the governor, it will not be updated an will continue to be zero.

Proper fix is to initialize the curent state of the cooling device before
thermal governor tries to change it. For now, as a workaround, ensure
that the state of the cooling device will be updated even if it matches
the target one.