### PR TITLE
arch: arm64: dts: add labels to mt8365 cooling maps

### DIFF
--- a/arch/arm64/boot/dts/mediatek/mt8365.dtsi
+++ b/arch/arm64/boot/dts/mediatek/mt8365.dtsi
@@ -247,7 +247,7 @@
 			};
 
 			cooling-maps {
-				map0 {
+				map0: map0 {
 					trip = <&threshold>;
 					cooling-device =
 						<&cpu0
@@ -264,8 +264,7 @@
 						 THERMAL_NO_LIMIT>;
 					contribution = <100>;
 				};
-
-				map1 {
+				map1: map1 {
 					trip = <&target>;
 					cooling-device =
 						<&cpu0


### PR DESCRIPTION
arch: arm64: dts: add labels to mt8365 cooling maps
From BL:
Add labels to the mt8365 cooling maps so that board specific
devicetrees might be able to reference them.

Signed-off-by: Vitor Sato Eschholz <vsatoes@baylibre.com>