### PR TITLE
BayLibre - rtc: mt6397: Remove RTC wakeup

### DIFF
--- a/drivers/rtc/rtc-mt6397.c
+++ b/drivers/rtc/rtc-mt6397.c
@@ -385,8 +385,6 @@ static int mtk_rtc_probe(struct platform_device *pdev)
 		return ret;
 	}
 
-	device_init_wakeup(&pdev->dev, 1);
-
 	rtc->rtc_dev->ops = &mtk_rtc_ops;
 
 	ret = rtc_register_device(rtc->rtc_dev);


### PR DESCRIPTION
Remove RTC wakeup to prevent device instant wakeup in S3

Signed-off-by: Stoyan Bogdanov [sbogdanov@baylibre.com](mailto:sbogdanov@baylibre.com)

Note: In Kernel 5.4, the system wakes up immediately after entering S3 mode due to the RTC.
By removing the RTC as a wakeup source, the system is able to remain in S3 mode properly.

Ticket:
https://github.com/geappliances/android.appliance-walloven-ui/issues/5086