### PR TITLE
WiFi: Add mtreset module to fix PMF enabled router connection issue

### DIFF
--- a/build.config.mediatek-restricted
+++ b/build.config.mediatek-restricted
@@ -13,7 +13,8 @@ EXT_MODULES="$EXT_MODULES mt7668-wifi-mod"
 RESTRICTED_MODULES_FILES=("wlan_drv_gen4_MT7663_prealloc.ko"
                           "wlan_drv_gen4_MT7663.ko"
                           "wlan_drv_gen4_MT7668_prealloc.ko"
-                          "wlan_drv_gen4_MT7668.ko")
+                          "wlan_drv_gen4_MT7668.ko"
+                          "mtreset_.ko")
 
 function rebuild_for_mt7663() {
   local EXT_MOD=mt7663-wifi-mod


### PR DESCRIPTION
This PR is related to the issue "Couldn't Connect Hero Field Test Unit To UniFi Express 7 Router with 6 Ghz WPA2/WPA3 & PMF Enabled".
https://github.com/geappliances/android.appliance-platform/issues/1401

Newer versions of the WiFi driver require the mtreset_ module.  
Without this module, the driver initialization fails, leading to connection issues when PMF is enabled on the router.  

This update modifies build.config to copy the mtreset module into the Android tree by adding it to the RESTRICTED_MODULES_FILES variable.  
The change is based on BayLibre's work, which identified this dependency and provided the necessary fix.  

With this update, devices can successfully connect to routers with PMF enabled.