### PR TITLE
[Display] Fix white screen flash on S3 resume

### DIFF
--- a/drivers/video/backlight/pwm_bl.c
+++ b/drivers/video/backlight/pwm_bl.c
@@ -698,6 +698,13 @@ static int pwm_backlight_resume(struct device *dev)
 {
 	struct backlight_device *bl = dev_get_drvdata(dev);
 
+	/*
+	 * Delay backlight enable to allow framebuffer
+	 * to be ready after S3 resume, preventing white
+	 * flash on screen.
+	 */
+	msleep(100);
+
 	backlight_update_status(bl);
 
 	return 0;


### PR DESCRIPTION
## Problem
White screen flash appears briefly when resuming from S3 sleep mode.

## Root Cause
The PWM backlight driver enables backlight immediately on S3 resume, 
before the framebuffer content is ready.

## Solution
Added msleep() delay in `pwm_backlight_resume()` to allow framebuffer 
to be ready before enabling backlight.

## Testing
- Verified white flash no longer appears on S3 resume
- Tested with 100ms delay - no noticeable UX impact

## Files Changed
- `drivers/video/backlight/pwm_bl.c`

## Ticket
[https://github.com/geappliances/android.appliance-walloven-ui/issues/5220](https://github.com/geappliances/android.appliance-walloven-ui/issues/5220)